### PR TITLE
refactor(cookie): 优化token和角色的cookie管理方法

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smanga",
-  "version": "4.2.85",
+  "version": "4.2.86",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/api/image.ts
+++ b/src/api/image.ts
@@ -20,7 +20,7 @@ const img = Axios.create({
 	transformRequest: [
 		(data, headers) => {
 			// 设置请求头
-			headers['token'] = Cookies.get('smanga-token');
+			headers['token'] = Cookies.getToken();
 			// 获取时间戳
 			const timestamp = new Date().getTime();
 			// 初始化传参

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -22,7 +22,7 @@ const ajax = Axios.create({
   transformRequest: [
     (data, headers) => {
       // 设置请求头
-      headers['token'] = Cookies.get('smanga-token');
+      headers['token'] = Cookies.getToken();
 
       // 判断是否为FormData或不需要JSON转换的情况
       const contentType = headers['Content-Type'] || headers['content-type'];

--- a/src/api/test.ts
+++ b/src/api/test.ts
@@ -25,7 +25,7 @@ export const testAxios = Axios.create({
     transformRequest: [
         data => {
             // 用户标识
-            const userId = Cookies.get('smanga-userId');
+            const userId = Cookies.getToken();
             // 获取时间戳
             const timestamp = new Date().getTime();
             // 初始化传参

--- a/src/components/notice.vue
+++ b/src/components/notice.vue
@@ -39,7 +39,7 @@ function socket_init() {
 	ws = new WebSocket(url);
 	ws.onopen = () => {
 		console.log('socket连接成功');
-		ws.send(Cookies.get('smanga-userId'));
+		ws.send(Cookies.getToken());
 	};
 
 	ws.onmessage = (e: any) => {

--- a/src/layout/components/sidebar.vue
+++ b/src/layout/components/sidebar.vue
@@ -205,7 +205,7 @@ const menuVisible = computed(() => (router: any) => {
   }
 
   // 是否需要管理员权限
-  const isAdmin = Cookies.get('smanga-role') === 'admin';
+  const isAdmin = Cookies.getRole() === 'admin';
   const onlyAdmin = router.meta?.onlyAdmin;
 
   if (onlyAdmin && !isAdmin) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -108,6 +108,84 @@ export const Cookies = {
         Cookies.set(key, '', -1);
         return key;
     },
+
+    /**
+     * 设置token
+     * @param token
+     * @param time
+     */
+    setToken: function (token: string, time = 365) {
+        const serverKey = Cookies.get('smanga-server-key');
+        if (!serverKey) return false;
+        return Cookies.set(serverKey + '-smanga-token', token, time);
+    },
+
+    /**
+     * 获取token
+     */
+    getToken: function () {
+        const serverKey = Cookies.get('smanga-server-key');
+        if (!serverKey) return '';
+        return Cookies.get(serverKey + '-smanga-token');
+    },
+
+    /**
+     * 移除token
+     */
+    removeToken: function () {
+        const serverKey = Cookies.get('smanga-server-key');
+        if (!serverKey) return false;
+        return Cookies.remove(serverKey + '-smanga-token');
+    },
+
+   /**
+     * 设置角色
+    * @param role 
+    * @param time 
+    * @returns 
+    */
+    setRole: function (role: string, time = 365) {
+        const serverKey = Cookies.get('smanga-server-key');
+        if (!serverKey) return false;
+        return Cookies.set(serverKey + '-smanga-role', role, time);
+    },
+    /**
+     * 获取角色
+     */
+    getRole: function () {
+        const serverKey = Cookies.get('smanga-server-key');
+        if (!serverKey) return '';
+        return Cookies.get(serverKey + '-smanga-role');
+    },
+    /**
+     * 设置带前缀的cookie
+     * @param serverKey 前缀
+     * @param key cookie键名
+     * @param value cookie值
+     * @param time 过期时间，单位为天
+     */
+    smangaSet: function (serverKey: string, key: string, value: string, time = 365) {
+        const fullKey = serverKey ? `${serverKey}_${key}` : key;
+        return Cookies.set(fullKey, value, time);
+    },
+    /**
+     * 获取带前缀的cookie
+     * @param serverKey 前缀
+     * @param key cookie键名
+     */
+    smangaGet: function (serverKey: string, key: string) {
+        const fullKey = serverKey ? `${serverKey}_${key}` : key;
+        return Cookies.get(fullKey);
+    },
+    /**
+     * 移除带前缀的cookie
+     * @param serverKey 前缀
+     * @param key cookie键名
+     */
+    smangaRemove: function (serverKey: string, key: string) {
+        const fullKey = serverKey ? `${serverKey}_${key}` : key;
+        return Cookies.remove(fullKey);
+    },
 }
 
 export function get_cookie(key: string) {

--- a/src/views/chapter-list/right-sidebar.vue
+++ b/src/views/chapter-list/right-sidebar.vue
@@ -84,7 +84,7 @@ const chapterId = computed(() => {
 });
 
 const isAdmin = computed(() => {
-  return Cookies.get('smanga-role') === 'admin';
+  return Cookies.getRole() === 'admin';
 });
 
 watch(

--- a/src/views/login/index.vue
+++ b/src/views/login/index.vue
@@ -127,11 +127,9 @@ async function do_login() {
 	if (!loginResponse) return;
 	// 缓存用户信息
 	Object.assign(userInfo, loginResponse);
-	Cookies.set('smanga-userName', loginResponse.userName);
-	Cookies.set('smanga-userId', loginResponse.userId);
-	Cookies.set('smanga-header', loginResponse.header);
-	Cookies.set('smanga-token', loginResponse.token)
-	Cookies.set('smanga-role', loginResponse.userRole)
+	Cookies.set('smanga-server-key', loginResponse.serverKey);
+	Cookies.setToken(loginResponse.token)
+	Cookies.setRole(loginResponse.userRole)
 
 	await router.push('/');
 

--- a/src/views/manga-list/right-sidebar.vue
+++ b/src/views/manga-list/right-sidebar.vue
@@ -115,7 +115,7 @@ const alreadyRead = computed(() => {
 });
 
 const isAdmin = computed(() => {
-	return Cookies.get('smanga-role') === 'admin';
+	return Cookies.getRole() === 'admin';
 });
 
 watch(

--- a/src/views/media-list/right-sidebar.vue
+++ b/src/views/media-list/right-sidebar.vue
@@ -62,7 +62,7 @@ const props = defineProps(['mediaInfo']);
 const emit = defineEmits(['reload', 'close']);
 
 const isAdmin = computed(() => {
-  return Cookies.get('smanga-role') === 'admin';
+  return Cookies.getRole() === 'admin';
 });
 
 watch(

--- a/version.json
+++ b/version.json
@@ -195,5 +195,19 @@
             "修复章节排序错误问题",
             "修复redis配置读取错误问题"
         ]
+    },
+    {
+        "version": "4.2.86",
+        "date": "2026-04-12",
+        "content": [
+            "新增token和角色的cookie统一管理方法(setToken/getToken/removeToken/setRole/getRole)",
+            "优化cookie键名管理,使用带前缀的方法(smangaSet/smangaGet/smangaRemove)避免冲突",
+            "修复鉴权中mediaId类型判断问题,避免Number转换错误",
+            "登录成功接口返回中增加serverKey配置字段",
+            "优化标签关联漫画及阅读计数统计查询,使用Prisma.raw提升性能",
+            "使用lodash优化漫画标签数据去重逻辑,提升性能",
+            "Auth中间件支持动态配置读取,初始化流程中添加serverKey配置生成逻辑",
+            "TagsController无分页查询中增加用户鉴权与媒体权限过滤"
+        ]
     }
 ]


### PR DESCRIPTION
- 在utils中新增setToken、getToken、removeToken方法统一管理token
- 新增setRole、getRole方法统一管理用户角色信息
- 使用带前缀的方法smangaSet、smangaGet、smangaRemove管理cookie键名避免冲突
- 全局替换代码中直接使用Cookies.get('smanga-token')等为新封装的方法
- 登录逻辑调整，改为使用setToken/setRole存储token和角色
- websocket连接和请求头中使用getToken获取token
- 菜单权限判断统一使用getRole获取角色信息
- 版本号升级至4.2.86